### PR TITLE
increase missing illuminate requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     "license": "MIT",
     "require": {
         "php" : ">=8.0.2",
-        "illuminate/database": "^8.0",
-        "illuminate/events": "^8.0",
+        "illuminate/database": "^9.0",
+        "illuminate/events": "^9.0",
         "doctrine/dbal": "^2.5",
         "laravel/helpers": "^1.2"
     },


### PR DESCRIPTION
Sorry to miss it in the last PR.
Now I tested the integration and it's working 😅 

Not sure how many have already installed the new version 5 (suppose no one, as it was not working)... Thus, I think you can just release it as version 5.0 again